### PR TITLE
replace utf8 with "proper" mysql utf-8 support via utf8mb4

### DIFF
--- a/parse_osc.pl
+++ b/parse_osc.pl
@@ -48,7 +48,7 @@ if( $help ) {
 
 usage("Please specify database and user names") unless $database && $user;
 my $db = DBIx::Simple->connect("DBI:mysql:database=$database;host=$dbhost;mysql_enable_utf8=1", $user, $password, {RaiseError => 1});
-$db->query("set names 'utf8'") or die "Failed to set utf8 in mysql";
+$db->query("set names 'utf8mb4'") or die "Failed to set utf8 in mysql";
 create_table() if $clear;
 my $ua = LWP::UserAgent->new();
 $ua->env_proxy;
@@ -178,7 +178,7 @@ create table whosthat (
 	primary key (user_id, user_name),
 	index idx_name (user_name),
         index idx_last (date_last)
-)
+) CHARACTER SET utf8mb4
 CREAT1
     $db->query($sql) or die $db->error;
     print STDERR "Database tables were recreated.\n" if $verbose;

--- a/whosthat.php
+++ b/whosthat.php
@@ -8,7 +8,7 @@ if( isset($_REQUEST['action']) ) {
     if ($db->connect_errno) {
         $result['error'] = "Failed to connect to MySQL: (" . $db->connect_errno . ") " . $db->connect_error;
     } else {
-        $db->set_charset('utf8');
+        $db->set_charset('utf8mb4');
 
         $ids = array();
         if( isset($_REQUEST['id']) && preg_match('/^\d+$/', $_REQUEST['id']) ) {


### PR DESCRIPTION
Without this, user names containing special unicode characters cannot be stored. See for example https://stackoverflow.com/a/13754976 for more background info.

Without this patch, I was seeing errors like the following while populating the database

```
http://planet.openstreetmap.org/replication/day/000/000/622.osc.gz: reading...3130 users, writing...Transaction failed: DBD::mysql::st execute failed: Incorrect string value: '\xF0\x9F\x9A\x81\xF0\x9F...' for column 'user_name' at row 1 at /usr/local/share/perl/5.22.1/DBIx/Simple.pm line 172, <GEN1> line 9932731.
```

this is [user 2092144 aka "🚁🚗🚓🚲"](http://www.openstreetmap.org/user/%F0%9F%9A%81%F0%9F%9A%97%F0%9F%9A%93%F0%9F%9A%B2) btw. :heart_eyes_cat: :heart_eyes_cat:, which also doesn't seem to get displayed properly when requested on [whosthat.osmz.ru](http://whosthat.osmz.ru/?id=2092144):

```bash
$ curl "http://whosthat.osmz.ru/whosthat.php?action=info&id=2092144"
[{"id":"2092144","names":[{"name":"","first":"2014-05-25","last":"2014-06-02"}]}]
```