### PR TITLE
Add manual username refresh from OSM API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,14 @@ or JSONP (if you specify `jsonp=<name>` parameter). It has following actions:
     It's an array of strings.
   * `action=names`: returns all names for specified users, sorted by date.
     It's an array of hashes: `id` for user id and `names` for an array of user names.
-  * `action=info`: returns detailed information on name changes for specidied users.
+  * `action=info`: returns detailed information on name changes for specified users.
     It's an array of hashes: `id` and `names`, the latter contains array of hashes
     with `name` for user name, `first` for the first spotted usage in database
     and `last` for the last one.
   * `action=recent`: returns 15 last renamings.
     It's an array of hashes with `id`, `date`, `from` and `to` keys.
+  * `action=refresh`: returns current username for a specified user ID directly
+    from OSM API and updates the database. It's an array with a single string.
 
 To specify users, use one of those parameters:
 

--- a/www/index.html
+++ b/www/index.html
@@ -133,8 +133,16 @@ function setId(uid) {
     });
 }
 
+function refreshId(uid) {
+    ajax(server + '?action=refresh&id=' + uid, function(result) {
+        if( result.length > 0 ) {
+            setId(uid);
+        }
+    });
+}
+
 function infoToString(info) {
-    var line = '<div class="info"><div class="info-id">#'+info['id']+'</div>';
+    var line = '<div class="info"><div class="header"><div class="info-id">#'+info['id']+'</div> <a href="#" onclick="refreshId('+info['id']+'); return false;">(refresh)</a></div>';
     for( var i = 0; i < info['names'].length; i++ ) {
         var name = info['names'][i]['name'];
         name = i + 1 == info['names'].length ? '<a href="'+osmUser+encodeURIComponent(name)+'" target="_blank">'+escapeHtml(name)+'</a>' : escapeHtml(name);
@@ -188,9 +196,12 @@ function escapeHtml(str) {
         margin-bottom: 2em;
         margin-left: 1em;
     }
-    .info-id {
-        font-weight: bold;
+    .info .header {
         margin-left: -1em;
+    }
+    .info-id {
+        display: inline-block;
+        font-weight: bold;
     }
     .info .name {
         display: inline-block;

--- a/www/index.html
+++ b/www/index.html
@@ -142,12 +142,13 @@ function refreshId(uid) {
 }
 
 function infoToString(info) {
-    var line = '<div class="info"><div class="header"><div class="info-id">#'+info['id']+'</div> <a href="#" onclick="refreshId('+info['id']+'); return false;">(refresh)</a></div>';
+    var line = '<div class="info"><div class="header"><span class="info-id">#'+info['id']+'</span> <a href="#" onclick="refreshId('+info['id']+'); return false;">(refresh)</a></div>';
     for( var i = 0; i < info['names'].length; i++ ) {
         var name = info['names'][i]['name'];
         name = i + 1 == info['names'].length ? '<a href="'+osmUser+encodeURIComponent(name)+'" target="_blank">'+escapeHtml(name)+'</a>' : escapeHtml(name);
         line += '<div><span class="name">'+name+'</span> <span class="interval">'+normalDate(info['names'][i]['first'])+'&mdash;'+normalDate(info['names'][i]['last'])+'</span></div>';
     }
+    line += '</div>';
     return line;
 }
 


### PR DESCRIPTION
Currently users who change their names but don't create any changesets afterwards cannot be detected by the existing parse_osc.pl script. This PR adds a manual refresh feature to the frontend and the backend that fetches the current username directly from OSM API. Just click "(refresh)" next to any user ID to update their name. It can also be very useful for some users (I know at least one) who change their names in between changesets. There should be no problems with timezones because this code uses SQL's CURDATE(), which uses DB's timezone (according to the [dump](https://whosthat.osmz.ru/whosthat.tgz), it should be UTC).