### PR TITLE
Add combined ID and username search

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -94,15 +94,25 @@ function userFieldChanged() {
 
 function updateAutocomplete() {
     var str = document.getElementById('formuser').value;
-    if( str == lastString ) return;
+    if( str == lastString || str == '' ) return;
     lastString = str;
+    var id = /^\s*\d+\s*$/.test(str) ? Number(str) : null; // Without regex Number('46.0') and Number('0x2E') would return 46 and we don't want that
     ajax(server + '?action=names&q=' + encodeURIComponent(str), function(result) {
         var line = '';
         for( var i = 0; i < result.length; i++ ) {
-            line += '<div class="found"><a href="?id='+result[i]['id']+'">#'+result[i]['id']+'</a>: <span class="'+(result[i]['names'].length>1 ? 'foundmany':'foundone')+'">'+escapeHtml(result[i]['names'].join(', '))+'</span></div>';
+            // If a matching entry for an ID exists, it will be reinserted later by ID search
+            if( result[i]['id'] != id ) line += '<div class="found"><a href="?id='+result[i]['id']+'">#'+result[i]['id']+'</a>: <span class="'+(result[i]['names'].length>1 ? 'foundmany':'foundone')+'">'+escapeHtml(result[i]['names'].join(', '))+'</span></div>';
         }
-        if( line == '' && str.length > 3 ) line = 'No users found';
-        document.getElementById('results').innerHTML = line;
+        if (id) {
+            ajax(server + '?action=names&id=' + id, function(result) {
+                if( result.length == 1 ) line = '<div class="found foundid"><a href="?id='+result[0]['id']+'">#'+result[0]['id']+'</a>: <span class="'+(result[0]['names'].length>1 ? 'foundmany':'foundone')+'">'+escapeHtml(result[0]['names'].join(', '))+'</span></div>' + line;
+                if( line == '' ) line = 'No users found'; // No check for str.length, it must be > 0 if id is set
+                document.getElementById('results').innerHTML = line;
+            });
+        } else {
+            if( line == '' && str.length > 3 ) line = 'No users found';
+            document.getElementById('results').innerHTML = line;
+        }
     });
 }
 
@@ -180,6 +190,9 @@ function escapeHtml(str) {
     .date {
         color: #777;
         padding-right: 1em;
+    }
+    .foundid {
+        font-weight: bold;
     }
     .foundone {
         color: #777;

--- a/www/whosthat.php
+++ b/www/whosthat.php
@@ -14,7 +14,7 @@ if( isset($_REQUEST['action']) ) {
 
         $ids = array();
         if( isset($_REQUEST['id']) && preg_match('/^\d+$/', $_REQUEST['id']) ) {
-            $ids[] = $_REQUEST['id'];
+            $ids[] = ltrim($_REQUEST['id'], '0');
         }
         elseif( isset($_REQUEST['name']) && strlen($_REQUEST['name']) > 0 ) {
             $res = $db->query('select user_id from whosthat where user_name = \''.$db->escape_string($_REQUEST['name']).'\'');
@@ -36,8 +36,8 @@ if( isset($_REQUEST['action']) ) {
             foreach( $ids as $id ) {
                 $res2 = $db->query("select user_name from whosthat where user_id = $id order by date_last desc limit 1");
                 $row = $res2->fetch_row();
-                $result[] = $row[0];
-                $res2->close(); 
+                if( $row ) $result[] = $row[0];
+                $res2->close();
             }
 
         } elseif( $action == 'info' ) { // Search for user, get all info on each
@@ -51,11 +51,13 @@ if( isset($_REQUEST['action']) ) {
                         'last' => $row['date_last']
                     );
                 }
-                $res2->close(); 
-                $result[] = array(
-                    'id' => $id,
-                    'names' => $u
-                );
+                $res2->close();
+                if( !empty($u) ) {
+                    $result[] = array(
+                        'id' => $id,
+                        'names' => $u
+                    );
+                }
             }
 
         } elseif( $action == 'names' ) { // Get history of username changes
@@ -66,7 +68,7 @@ if( isset($_REQUEST['action']) ) {
                     $names[] = $row['user_name'];
                 }
                 $res2->close();
-                $result[] = array( 'id' => $id, 'names' => $names );
+                if( !empty($names) ) $result[] = array( 'id' => $id, 'names' => $names );
             }
 
         } elseif( $action == 'recent' ) { // Get recent user renames


### PR DESCRIPTION
Closes #8 😁

Now for every user's query the frontend makes up to two API requests, one (always) for usernames and one (only if it's a valid number) for UID. When sending two API calls, both must complete before showing the results. Any found UID is displayed on top of the results in bold. In some cases a UID can be a [part of](https://whosthat.osmz.ru/?id=6683) or the [entire](https://whosthat.osmz.ru/?id=42429) username, so it's possible for UID to show up in results of both API calls. The frontend protects against that by always removing the queried UID from the username API results, so the only way the UID can show up on the page is from the UID API result.

Drive-by fixes:
- API no longer returns empty username history for UIDs that don't exist in the database. It was necessary before starting any frontend work since it fooled the frontend into thinking that any queried UID always existed and "No users found" message had no chance to occur.
- In order to be consistent with OpenStreetMap API, if you provide Who's That API a UID with leading zeros, they get trimmed internally and any results are now returned without them.
- Empty query field now triggers an early exit within updateAutocomplete(). A side effect is that now after clearing the field the site keeps last search results instead of showing the blank page, but I guess it's a fair price for reducing unnecessary API calls.